### PR TITLE
Do not re-render the higher order component if the cursor reference hasn't changed.

### DIFF
--- a/src/higher-order.js
+++ b/src/higher-order.js
@@ -67,7 +67,7 @@ function root(tree, Component) {
 /**
  * Branch component
  */
-function branch(cursors, Component) {
+function branch(cursors, Component, opts) {
   if (typeof Component !== 'function')
     throw Error('baobab-react/higher-order.branch: given target is not a valid React component.');
 
@@ -151,6 +151,41 @@ function branch(cursors, Component) {
       // Refreshing the watcher
       this.watcher.refresh(mapping);
       this.setState(this.watcher.get());
+    }
+
+    // Should update the component?
+    shouldComponentUpdate(nextProps, nextState) {
+      if (!(opts && opts.pure)) {
+        return true
+      }
+
+      propsKeys = Object.keys(this.props)
+      nextPropsKeys = Object.keys(nextProps)
+
+      stateKeys = Object.keys(this.state)
+      nextStateKeys = Object.keys(nextState)
+
+      if (!(propsKeys.length === nextPropsKeys.length && stateKeys.length === nextStateKeys.length)) {
+        return true
+      }
+
+      propsEqual = propsKeys.every(function (key) {
+        return this.props[key]  === nextProps[key]
+      })
+
+      if (!propsEqual) {
+        return true
+      }
+
+      stateEqual = stateKeys.every(function (key) {
+        return this.state[key]  === nextState[key]
+      })
+
+      if (!stateEqual) {
+        return true
+      }
+
+      return false
     }
   };
 

--- a/test/higher-order.jsx
+++ b/test/higher-order.jsx
@@ -194,7 +194,7 @@ describe('Higher Order', function() {
       done();
     });
 
-    it('should not re-render the component if cursor reference hasnt changed.', function(done) {
+    it('should not re-render the component if cursor reference hasnt changed if we pass pure option to the branch.', function(done) {
       var address = {apt: "221B", street: "Baker St"}
       const tree = new Baobab({name: 'Sherlock', address: address}, {asynchronous: false});
 
@@ -222,6 +222,75 @@ describe('Higher Order', function() {
       const wrapper = mount(<Root tree={tree}><BranchedChild /></Root>);
 
       tree.set('address', address);
+      tree.commit();
+
+      assert.strictEqual(numRendered, 1);
+      done();
+    });
+
+    it('should not re-render the component if value was changed at the reference, even if pure option is not passed to the branch.', function(done) {
+      var address = {apt: "221B", street: "Baker St"}
+      const tree = new Baobab({name: 'Sherlock', address: address}, {asynchronous: false, immutable: false});
+
+      var numRendered = 0
+
+      class Child extends Component {
+        render() {
+          numRendered++
+
+          return (
+            <span>
+              {this.props.name}, stays at {this.props.address.apt} {this.props.address.street}
+            </span>
+          );
+        }
+      }
+
+      const Root = root(tree, BasicRoot);
+
+      const BranchedChild = branch({
+        name: 'name',
+        address: 'address'
+      }, Child);
+
+      const wrapper = mount(<Root tree={tree}><BranchedChild /></Root>);
+
+      address["apt"] = "221A"
+      tree.set('address', address);
+      tree.commit();
+
+      assert.strictEqual(numRendered, 1);
+      done();
+    });
+
+    it('should not re-render the component if the leaf cursor value hasnt changed, even if we dont pass pure option to the branch.', function(done) {
+      var address = {apt: "221B", street: "Baker St"}
+      const tree = new Baobab({name: 'Sherlock', address: address}, {asynchronous: false});
+
+      var numRendered = 0
+
+      class Child extends Component {
+        render() {
+          numRendered++
+
+          return (
+            <span>
+              {this.props.name}, stays at {this.props.address.apt} {this.props.address.street}
+            </span>
+          );
+        }
+      }
+
+      const Root = root(tree, BasicRoot);
+
+      const BranchedChild = branch({
+        name: 'name',
+        address: 'address'
+      }, Child);
+
+      const wrapper = mount(<Root tree={tree}><BranchedChild /></Root>);
+
+      tree.set(['address', 'apt'], "221B");
       tree.commit();
 
       assert.strictEqual(numRendered, 1);

--- a/test/higher-order.jsx
+++ b/test/higher-order.jsx
@@ -188,11 +188,44 @@ describe('Higher Order', function() {
       const wrapper = mount(<Root tree={tree}><BranchedChild /></Root>);
 
       tree.set('surname', 'the Third');
+      tree.commit();
 
-      setTimeout(() => {
-        assert.strictEqual(wrapper.text(), 'Hello John the Third');
-        done();
-      }, 50);
+      assert.strictEqual(wrapper.text(), 'Hello John the Third');
+      done();
+    });
+
+    it('should not re-render the component if cursor reference hasnt changed.', function(done) {
+      var address = {apt: "221B", street: "Baker St"}
+      const tree = new Baobab({name: 'Sherlock', address: address}, {asynchronous: false});
+
+      var numRendered = 0
+
+      class Child extends Component {
+        render() {
+          numRendered++
+
+          return (
+            <span>
+              {this.props.name}, stays at {this.props.address.apt} {this.props.address.street}
+            </span>
+          );
+        }
+      }
+
+      const Root = root(tree, BasicRoot);
+
+      const BranchedChild = branch({
+        name: 'name',
+        address: 'address'
+      }, Child, {pure: true});
+
+      const wrapper = mount(<Root tree={tree}><BranchedChild /></Root>);
+
+      tree.set('address', address);
+      tree.commit();
+
+      assert.strictEqual(numRendered, 1);
+      done();
     });
 
     it('should be possible to set cursors with a function.', function(done) {
@@ -220,11 +253,10 @@ describe('Higher Order', function() {
       const wrapper = mount(<Root tree={tree}><BranchedChild path={['surname']}/></Root>);
 
       tree.set('surname', 'the Third');
+      tree.commit();
 
-      setTimeout(() => {
-        assert.strictEqual(wrapper.text(), 'Hello John the Third');
-        done();
-      }, 50);
+      assert.strictEqual(wrapper.text(), 'Hello John the Third');
+      done();
     });
 
     it('wrapper component should return wrapping component instance by getDecoratedComponentInstance.', function() {


### PR DESCRIPTION
@ConradIrwin, @ibash the test fails if you remove the fix.

A quick experiment on our app tells me that it'll reduce the total number of renders for baobab wrapped components by 38%, NOT including their children. Turns out so many baobab components were getting re-rendered for no reason. 🎆 

<img width="945" alt="screen shot 2017-03-23 at 8 01 46 pm" src="https://cloud.githubusercontent.com/assets/5691667/24278876/d4734f58-1003-11e7-92b3-fd0150cc4c25.png">
